### PR TITLE
add property to show all multi options in the menu

### DIFF
--- a/src/Option.js
+++ b/src/Option.js
@@ -12,8 +12,14 @@ const Option = React.createClass({
 		onSelect: React.PropTypes.func,                // method to handle click on option element
 		onUnfocus: React.PropTypes.func,               // method to handle mouseLeave on option element
 		option: React.PropTypes.object.isRequired,     // object that is base for that option
+		showCheckedIcon: React.PropTypes.bool          // show/hide cheched icon (used for multuple options select)
 	},
-	blockEvent (event) {
+    getInitialState: function() {
+        return {
+            isChecked: this.props.isSelected
+        };
+    },
+    blockEvent (event) {
 		event.preventDefault();
 		event.stopPropagation();
 		if ((event.target.tagName !== 'A') || !('href' in event.target)) {
@@ -30,6 +36,9 @@ const Option = React.createClass({
 		event.preventDefault();
 		event.stopPropagation();
 		this.props.onSelect(this.props.option, event);
+        this.setState({
+            isChecked: !this.state.isChecked
+        });
 	},
 
 	handleMouseEnter (event) {


### PR DESCRIPTION
Add property `showAllOptions` (disabled by default), which works only for multi select dropdown and allows to not remove selected options from the menu when user selects the option, but instead search among all options (including selected). Works very similar to [bootstrap-select](https://silviomoreto.github.io/bootstrap-select/examples/) library ("Multiple select boxes" section).