### PR TITLE
Update react-input-autosize to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "classnames": "^2.2.4",
-    "react-input-autosize": "^0.6.13"
+    "react-input-autosize": "^1.1.0"
   },
   "devDependencies": {
     "babel": "^5.8.23",


### PR DESCRIPTION
This solves an issue where a warning is thrown about minWidth.
See: https://github.com/JedWatson/react-select/pull/1090 for more info