### PR TITLE
Update to JedWatson/react-select v1.0.0-rc.5

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 # React-Select-Plus
 
+## v1.0.0-rc.5 / 2017-05-25
+
+* fixed; Allow `falsey` values to be clearable, thanks [Simon Gaestel](https://github.com/sgaestel)
+* fixed; issue where Firefox would crash due to incorrect use of `aria-owns` attribute, thanks [Max Hubenthal](https://github.com/mhubenthal)
+* fixed; regression where options not using the value key couldn't be focused, thanks [Benjamin Piouffle](https://github.com/Betree)
+
 ## v1.0.0-rc.4 / 2017-05-14
 
 * fixed; no more warning when using React 15.5, thanks [Adam Girton](https://github.com/agirton)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-select-plus",
-  "version": "1.0.0-rc.4",
+  "version": "1.0.0-rc.5",
   "description": "A fork of react-select with support for option groups",
   "main": "lib/Select.js",
   "style": "dist/react-select-plus.min.css",


### PR DESCRIPTION
We actually brought in all of the substantive changes as part of #73. This PR just updates the `HISTORY.md` and gives us version number parity. It also gives us a release to incorporate #75.