### PR TITLE
allowing input value overriding via props

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -924,7 +924,7 @@ class Select extends React.Component {
 			role: 'combobox',
 			required: this.state.required,
 			tabIndex: this.props.tabIndex,
-			value: this.props.inputProps.value || '',
+			value,
 		};
 
 		if (this.props.inputRenderer) {

--- a/src/Select.js
+++ b/src/Select.js
@@ -924,7 +924,7 @@ class Select extends React.Component {
 			role: 'combobox',
 			required: this.state.required,
 			tabIndex: this.props.tabIndex,
-			value,
+			value: this.props.inputProps.value || '',
 		};
 
 		if (this.props.inputRenderer) {

--- a/src/Select.js
+++ b/src/Select.js
@@ -901,7 +901,7 @@ class Select extends React.Component {
 				&& !this.state.inputValue
 		});
 
-		let value = this.state.inputValue;
+		let value = this.props.inputProps.value || this.state.inputValue;
 		if (value && !this.props.onSelectResetsInput && !this.state.isFocused){
 			// it hides input value when it is not focused and was not reset on select
 			value= '';


### PR DESCRIPTION
updated render input function for it.

Use Case:

- When the field has default value
- When user enters value and selects values from options and wants to edit then the select value would be the input value as well

It would be very much appreciated if this PR can be merged!

I would immediately then update my package.json with the new release version of its npm module!